### PR TITLE
feat: new wit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,22 +586,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "pinterest-capi-component"
-version = "0.6.0"
-dependencies = [
- "anyhow",
- "cargo-llvm-cov",
- "chrono",
- "pretty_assertions",
- "serde",
- "serde_json",
- "sha2",
- "url",
- "uuid",
- "wit-bindgen",
-]
-
-[[package]]
 name = "normpath"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +635,23 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pinterest-capi-component"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cargo-llvm-cov",
+ "chrono",
+ "log",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "sha2",
+ "url",
+ "uuid",
+ "wit-bindgen",
+]
 
 [[package]]
 name = "pretty_assertions"

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ This component implements the data collection protocol between [Edgee](https://w
 
 ```toml
 [[destinations.data_collection]]
-name = "pinterest_capi"
-component = "/var/edgee/components/pinterest_capi.wasm"
-credentials.pinterest_access_token = "YOUR_ACCESS_TOKEN"
-credentials.pinterest_ad_account_id = "YOUR_AD_ACCOUNT_ID"
-credentials.is_test = "true" # Optional
+id = "pinterest_capi"
+file = "/var/edgee/components/pinterest_capi.wasm"
+settings.pinterest_access_token = "YOUR_ACCESS_TOKEN"
+settings.pinterest_ad_account_id = "YOUR_AD_ACCOUNT_ID"
+settings.is_test = "true" # Optional
 ```
 
 ## Event Handling
@@ -66,22 +66,22 @@ edgee.user({
 ### Basic Configuration
 ```toml
 [[destinations.data_collection]]
-name = "pinterest_capi"
-component = "/var/edgee/components/pinterest_capi.wasm"
-credentials.pinterest_access_token = "YOUR_ACCESS_TOKEN"
-credentials.pinterest_ad_account_id = "YOUR_AD_ACCOUNT_ID"
-credentials.pinterest_test_event_code = "TEST_EVENT_CODE" # Optional
+id = "pinterest_capi"
+file = "/var/edgee/components/pinterest_capi.wasm"
+settings.pinterest_access_token = "YOUR_ACCESS_TOKEN"
+settings.pinterest_ad_account_id = "YOUR_AD_ACCOUNT_ID"
+settings.pinterest_test_event_code = "TEST_EVENT_CODE" # Optional
 
 # Optional configurations
-config.default_consent = "pending" # Set default consent status
+settings.default_consent = "pending" # Set default consent status
 ```
 
 ### Event Controls
 Control which events are forwarded to Pinterest CAPI:
 ```toml
-config.page_event_enabled = true   # Enable/disable page view tracking
-config.track_event_enabled = true  # Enable/disable custom event tracking
-config.user_event_enabled = true   # Enable/disable user identification
+settings.page_event_enabled = true   # Enable/disable page view tracking
+settings.track_event_enabled = true  # Enable/disable custom event tracking
+settings.user_event_enabled = true   # Enable/disable user identification
 ```
 
 ### Consent Management

--- a/src/pinterest_payload.rs
+++ b/src/pinterest_payload.rs
@@ -17,8 +17,8 @@ pub(crate) struct PinterestPayload {
 }
 
 impl PinterestPayload {
-    pub fn new(cred_map: Dict) -> anyhow::Result<Self> {
-        let cred: HashMap<String, String> = cred_map
+    pub fn new(settings: Dict) -> anyhow::Result<Self> {
+        let cred: HashMap<String, String> = settings
             .iter()
             .map(|(key, value)| (key.to_string(), value.to_string()))
             .collect();

--- a/wit/deps.lock
+++ b/wit/deps.lock
@@ -1,4 +1,4 @@
 [protocols]
-url = "https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.3.0.tar.gz"
-sha256 = "4d412367fff6f826280acbe95f7067e362d9299d76e60994981e7e27c74d1576"
-sha512 = "65021cace5ed07990fdfb563699accb975a31cb22311739ff6189849b969b06b564a0f8f72de154fd086ba474757d3cffaef0175778e4989c467280cf1c86284"
+url = "https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.4.0.tar.gz"
+sha256 = "8b5c8ea97c81d1d6cf4f227e75afb8c4dc5c0a411c3a0401fb7e4f7b745e21ba"
+sha512 = "16771cd12095409e7c4857a8f5c0b4ad680959e3c35dcd7999e11131bcce05d3b1a1b829daefceabbd853ae5b7f6453e3e359ddfbdebd6e2a94db6c55780368f"

--- a/wit/deps.toml
+++ b/wit/deps.toml
@@ -1,1 +1,1 @@
-protocols="https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.3.0.tar.gz"
+protocols="https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.4.0.tar.gz"

--- a/wit/deps/protocols/consent-mapping.wit
+++ b/wit/deps/protocols/consent-mapping.wit
@@ -1,7 +1,7 @@
 package edgee:protocols;
 
 interface consent-mapping {
-    type config = list<tuple<string,string>>;
+    type dict = list<tuple<string,string>>;
 
     enum consent {
         pending,
@@ -9,5 +9,5 @@ interface consent-mapping {
         denied,
     }
 
-    map: func(cookie: string, config: config) -> option<consent>;
+    map: func(cookie: string, settings: dict) -> option<consent>;
 }

--- a/wit/deps/protocols/data-collection.wit
+++ b/wit/deps/protocols/data-collection.wit
@@ -102,12 +102,13 @@ interface data-collection {
         method: http-method,
         url: string,
         headers: dict,
+        forward-client-headers: bool,
         body: string,
     }
 
     enum http-method { GET, PUT, POST, DELETE }
 
-    page: func(e: event, cred: dict) -> result<edgee-request, string>;
-    track: func(e: event, cred: dict) -> result<edgee-request, string>;
-    user: func(e: event, cred:dict) -> result<edgee-request, string>;
+    page: func(e: event, settings: dict) -> result<edgee-request, string>;
+    track: func(e: event, settings: dict) -> result<edgee-request, string>;
+    user: func(e: event, settings:dict) -> result<edgee-request, string>;
 }


### PR DESCRIPTION
New wit protocol

- `edgee-request` has now a new field `forward-client-headers`
- change `credentials` with `settings`
- Adapt Readme to reflect latest toml changes