### PR TITLE
Fix build command to handle hardlink issue on Linux

### DIFF
--- a/edgee-component.toml
+++ b/edgee-component.toml
@@ -16,7 +16,7 @@ icon-path = "pinterest.png"
 language = "Rust"
 
 [component.build]
-command = "cargo build --target wasm32-wasip2 --release && cp ./target/wasm32-wasip2/release/pinterest_capi_component.wasm pinterest_capi.wasm"
+command = "cargo build --target wasm32-wasip2 --release && rm -f pinterest_capi.wasm && cp ./target/wasm32-wasip2/release/pinterest_capi_component.wasm pinterest_capi.wasm"
 output_path = "pinterest_capi.wasm"
 
 [component.settings.pinterest_ad_account_id]


### PR DESCRIPTION
## Summary
- Add `rm -f [output_file]` before `mv`/`cp` operations in build commands
- Prevents "cannot move file to itself" errors on Linux where output WASM file is already a hardlink